### PR TITLE
Bundled Fabric Language Kotlin #25

### DIFF
--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -17,11 +17,16 @@ version = fabricModVersion
 
 repositories {
     mavenCentral()
+    maven {
+        url = "http://maven.fabricmc.net/"
+        name = "Fabric"
+    }
 }
 
 dependencies {
     compile(project(":common"))
-    compile(kotlin("stdlib-jdk8")) // using 'implementation' doesn't allow us to bundle this
+    //compile(kotlin("stdlib-jdk8")) // using 'implementation' doesn't allow us to bundle this
+    include(modImplementation(group = "net.fabricmc", name = "fabric-language-kotlin", version = "1.5.0+kotlin.1.4.31"))
     minecraft("com.mojang:minecraft:$fabricLatestMCVersion")
     mappings("net.fabricmc:yarn:$fabricMappingsVersion:v2")
     modImplementation("net.fabricmc:fabric-loader:[$fabricMinLoaderVersion,)")

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -17,8 +17,7 @@ version = fabricModVersion
 
 repositories {
     mavenCentral()
-    maven {
-        url = "http://maven.fabricmc.net/"
+    maven (url = "http://maven.fabricmc.net/") {
         name = "Fabric"
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -18,20 +18,20 @@
 
   "environment": "*",
   "entrypoints": {
-    "main": [
-      "mod.lucky.fabric.FabricMod"
-    ],
-    "client": [
-      "mod.lucky.fabric.FabricModClient"
-    ]
+    "main": [{
+      "adapter": "kotlin",
+      "value":   "mod.lucky.fabric.FabricMod"
+     }],
+    "client": [{
+      "adapter": "kotlin",
+      "value":   "mod.lucky.fabric.FabricModClient"
+    }]
   },
 
   "depends": {
     "fabricloader": ">=${fabricMinLoaderVersion}",
     "fabric": "*",
-    "minecraft": "${fabricMCTargetVersion}"
-  },
-  "suggests": {
-    "another-mod": "*"
+    "minecraft": "${fabricMCTargetVersion}",
+    "fabric-language-kotlin": "*"
   }
 }


### PR DESCRIPTION
Do not simply extract Kotlin-JVM Runtime into the JAR!  
~~First, it will occupy part of your compile time.~~  
Most of the Kotlin-based Fabric mods use Fabric Language Kotlin as an API, which includes Kotlin runtime safely.  
If you don't wanna let players download any dependencies (except Fabric API), you can click the "merge" button now cuz this PR bundles Fabric Language Kotlin.  
  
Good Luck™!